### PR TITLE
feat: strip useHead and api prefetching artifacts

### DIFF
--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,7 +1,14 @@
 <template>
   <div>This page needs no JavaScript (of course!)!</div>
 </template>
-
+<script lang="ts" setup>
+useHead({
+  // testing that this should be removed
+  link: [
+    { rel: 'prefetch', href: '/api/prefetch' }
+  ]
+})
+</script>
 <style scoped>
 div {
   color: red;

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -4,6 +4,6 @@ export default defineNuxtConfig({
   modules: ['nuxt-zero-js'],
   zeroJs: {
     // Enable module in dev mode
-    enabled: true,
+    disabled: false,
   }
 })

--- a/src/runtime/nitro-plugin.ts
+++ b/src/runtime/nitro-plugin.ts
@@ -15,5 +15,21 @@ export default <NitroAppPlugin> function (nitroApp) {
     if (i !== -1) {
       htmlContext.head[i] = htmlContext.head[i].replace(JS_HINT_RE, '')
     }
+
+    // clean up useHead artifacts
+    htmlContext.htmlAttrs = htmlContext.htmlAttrs.filter(a => !a.includes('data-head-attrs'))
+    htmlContext.bodyAttrs = htmlContext.bodyAttrs.filter(a => !a.includes('data-head-attrs'))
+    for (const k in htmlContext.head) {
+      // remove preload of api, i.e from nuxt/content
+      htmlContext.head[k] = htmlContext.head[k].replace(
+        /<link[^>]+rel="prefetch"[^>]+href="\/api\/[^"]*"[^>]*>/g,
+        ''
+      )
+      // remove head:count meta from @vueuse/head
+      htmlContext.head[k] = htmlContext.head[k].replace(
+        /<meta[^>]+name="head:count"[^>]+content="[^>]*"[^>]*>/g,
+        ''
+      )
+    }
   })
 }

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -11,11 +11,11 @@ describe('nuxt zero-js', async () => {
     const html = await $fetch('/')
     expect(html.replace(/\.[^.]+\.css/g, '.css').replace(/ data-v-[^>]*/g, ''))
       .toMatchInlineSnapshot(`
-      "<!DOCTYPE html>
-      <html data-head-attrs=\\"\\">
-      <head><title></title><meta charset=\\"utf-8\\"><meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1\\"><meta name=\\"head:count\\" content=\\"2\\"><link rel=\\"preload\\" as=\\"style\\" href=\\"/_nuxt/entry.css\\"><link rel=\\"stylesheet\\" href=\\"/_nuxt/entry.css\\"></head>
-      <body data-head-attrs=\\"\\"><div id=\\"__nuxt\\"><div>This page needs no JavaScript (of course!)!</div></div></body>
-      </html>"
-    `)
+        "<!DOCTYPE html>
+        <html >
+        <head><title></title><meta charset=\\"utf-8\\"><meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1\\"><link rel=\\"preload\\" as=\\"style\\" href=\\"/_nuxt/entry.css\\"><link rel=\\"stylesheet\\" href=\\"/_nuxt/entry.css\\"></head>
+        <body ><div id=\\"__nuxt\\"><div>This page needs no JavaScript (of course!)!</div></div></body>
+        </html>"
+      `)
   })
 })


### PR DESCRIPTION
With the module removing scripts from the HTML, there are a few artifacts left over which aren't being used for anything.

This PR removes Nuxt core ones (useHead) and pre-fetch API links from @nuxt/content.

I'm interested in your thoughts, and quite happy to close this PR if you think it doesn't belong. 

It may cause issues if / when island hydration is supported and I haven't done much coverage with the tests.